### PR TITLE
Integrate generic board code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
-# instrument-maker-board
+# Instrument Maker Board
 
 Arduino code for use with the Instrument Maker library in Pd or more generic MIDI applications.  
 
-Creates a MIDI controller for use with up to 8 analog sensors, including optional NeoPixel display.
+This is intended as an entry point for rapid instrument prototyping, so that workshop attendees can experience building a physical controller before thinking about code and breadboarding, with their respective access barriers.
+
+The result is a MIDI controller for use with up to 8 analog sensors, including optional NeoPixel visual feedback on the 6 sensor board.
+
+## Hardware
+The Instrument Maker Board is a shield for ATmega32u4 boards such as the Arduino Leonardo, Pro Micro, or Bare Conductive Touch Board. 
+
+The board offers 6-8 voltage dividers hardwired to analog inputs, which are then intended to be sent over USB as MIDI.
+If installed, a NeoPixel (WS2812) per channel displays the incoming sensor value mapped to brightness.
+
+## Outputs
+Channel 1: MIDI CC 1-6 (sensor range is compressed slightly) outputs a range of 0-127.
+
+## Inputs
+Channel 1: MIDI CC 1-6 emulates the sensor input, so that it can be recorded externally and played back for demo purposes.
+Channel 16: MIDI CC 1-6 sets the hue for the corresponding NeoPixel (red by default).

--- a/im-board-6/im-board-6.ino
+++ b/im-board-6/im-board-6.ino
@@ -1,4 +1,7 @@
-// For use with ATmega32u4-based boards such as the Arduino Leonardo
+// Charles Matthews 2024
+// Instrument Board setup with MIDI input for colour change.
+
+// For use with Arduino Leonardo or ATmega32u4-based boards.
 #include <Adafruit_NeoPixel.h>
 #include <MIDIUSB.h>
 
@@ -10,8 +13,9 @@
 #define NUMSENSORS 6
 const int sensors[NUMSENSORS] = {A0, A1, A2, A3, A4, A5};
 
-// Array to store the last sensor values to avoid duplicates
+
 int lastValues[NUMSENSORS] = {-1, -1, -1, -1, -1, -1};
+uint8_t hueValues[NUMSENSORS] = {0, 0, 0, 0, 0, 0};
 
 // Initialize NeoPixels
 Adafruit_NeoPixel pixels(NUMPIXELS, PIN, NEO_GRB + NEO_KHZ800);
@@ -27,55 +31,117 @@ void sendControlChange(uint8_t channel, uint8_t control, uint8_t value) {
   MidiUSB.flush(); // Ensure the MIDI message is sent immediately
 }
 
+// It's surprisingly difficult to map HSB to RGB for NeoPixels
+// Here I have hardcoded the values for red, green, blue, and interpolate the rest.
+/**
+ * @brief Converts Hue and Brightness to a 24-bit RGB value (fixed saturation).
+ * 
+ * @param hue 0-255
+ * @param brightness 0-255 
+ */
+uint32_t HBtoRGB(uint8_t hue, uint8_t val) {
+    uint8_t r, g, b;
+
+    if (hue <= 85) { // From Red to Green
+        r = 255 - (hue * 3); // Decrease red
+        g = hue * 3;         // Increase green
+        b = 0;               // Blue stays 0
+    } else if (hue <= 170) { // From Green to Blue
+        r = 0;                // Red stays 0
+        g = 255 - ((hue - 85) * 3); // Decrease green
+        b = (hue - 85) * 3;        // Increase blue
+    } else { // From Blue back to Red
+        r = (hue - 170) * 3;       // Increase red
+        g = 0;                     // Green stays 0
+        b = 255 - ((hue - 170) * 3); // Decrease blue
+    }
+
+    // Apply brightness (value)
+    r = (r * val) / 255;
+    g = (g * val) / 255;
+    b = (b * val) / 255;
+
+    return ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
+}
+
+/**
+ * @brief Extracts R, G, B components from a 24-bit RGB value and prints them.
+ * 
+ * @param rgb The 24-bit RGB value (0xRRGGBB).
+ */
+void printRGBComponents(uint32_t rgb) {
+  uint8_t r = (rgb >> 16) & 0xFF; // Extract the Red component
+  uint8_t g = (rgb >> 8) & 0xFF;  // Extract the Green component
+  uint8_t b = rgb & 0xFF;         // Extract the Blue component
+  
+  Serial.print("RGB Array: [R: ");
+  Serial.print(r);
+  Serial.print(", G: ");
+  Serial.print(g);
+  Serial.print(", B: ");
+  Serial.println(b);
+}
+
 void setup() {
   pixels.begin();
   Serial.begin(9600);
   
-  // Set sensor pins as input
   for (int i = 0; i < NUMSENSORS; i++) {
     pinMode(sensors[i], INPUT);
   }
 }
 
 void loop() {
-  int values[NUMSENSORS];
-  bool changeFlag = false;
- 
-  for (int i = 0; i < NUMSENSORS; i++) {
-    // Read the sensor value, map it to a range of 0-127, and invert it
-    values[i] = constrain((127 - (analogRead(sensors[i]) / 8) - 50), 0, 127); 
-    // Current IM boards only send a limited range, so boost this back up to 0-127
-    values[i] = constrain(map(values[i], 0, 76, 0, 127), 0, 127);
-    
-    Serial.print("Sensor ");
-    Serial.print(i);
-    Serial.print(": ");
-    Serial.print(values[i]);
-    Serial.print(" | ");
+    int values[NUMSENSORS];
+    bool changeFlag = false; // Flag to track if pixels need to be updated
 
-    // Debounce check: Only send MIDI if enough time has passed since the last change
-    if (values[i] != lastValues[i] && (millis() - lastDebounceTime[i] > debounceDelay)) {
-      sendControlChange(1, i, values[i]); // Control Change on channel 1
+    midiEventPacket_t rx = MidiUSB.read();
+    while (rx.header != 0) {
+        uint8_t status = rx.byte1 & 0xF0;  // Control Change status byte is 0xB0
+        uint8_t channel = (rx.byte1 & 0x0F) + 1; // MIDI channels 1-16
+        uint8_t control = rx.byte2;
+        uint8_t value = rx.byte3;
 
-      lastValues[i] = values[i];
-      lastDebounceTime[i] = millis();
-      
-      // Update the NeoPixel colors based on sensor values (red only)
-      pixels.setPixelColor(
-        i, 
-        pixels.Color(
-          values[i] / 2, 
-          constrain(values[i] / 3 - 50, 0, 127), 
-          constrain(values[i] / 3 - 50, 0, 127)
-        )
-      );
-      changeFlag = true;
+        // Check for Control Change messages on channel 16, CC 1-6
+        if (status == 0xB0 && channel == 16 && control >= 1 && control <= 6) {
+            uint8_t sensorIndex = control - 1; // 0-based index
+            hueValues[sensorIndex] = map(value, 0, 127, 0, 255); // Map CC value to hue (0-255)
+
+            // Use the current sensor value for brightness to update the NeoPixel color
+            uint32_t rgb = HBtoRGB(hueValues[sensorIndex], values[sensorIndex]);
+            pixels.setPixelColor(sensorIndex, rgb);
+            changeFlag = true;
+
+            // // Debugging: Print received MIDI message and color values
+            // Serial.print("Received MIDI CC ");
+            // Serial.print(control);
+            // Serial.print(" on channel ");
+            // Serial.print(channel);
+            // Serial.print(" with value ");
+            // Serial.println(value);
+            // printRGBComponents(rgb);
+        }
+        
+        rx = MidiUSB.read();  // Read next MIDI message
     }
-  }
-  
-  Serial.println("inputs: ");
-  
-  if (changeFlag) {
-    pixels.show();
-  }
+
+    for (int i = 0; i < NUMSENSORS; i++) {
+        values[i] = constrain((127 - (analogRead(sensors[i]) / 8) - 50), 0, 127);
+        values[i] = constrain(map(values[i], 0, 76, 0, 127), 0, 127);
+
+        if (values[i] != lastValues[i] || changeFlag) { // Update if there's a sensor change or a hue change via MIDI
+            sendControlChange(1, i, values[i]); // Control Change on channel 1
+            lastValues[i] = values[i];
+            lastDebounceTime[i] = millis();
+            
+            uint32_t rgb = HBtoRGB(hueValues[i], values[i]);  // Use sensor value for brightness
+            pixels.setPixelColor(i, rgb);
+            changeFlag = true; // Set flag to update the display
+        }
+    }
+    
+    // Update the NeoPixels display if any change is flagged
+    if (changeFlag) {
+        pixels.show();
+    }
 }

--- a/im-board-6/im-board-6.ino
+++ b/im-board-6/im-board-6.ino
@@ -1,22 +1,31 @@
-// Charles Matthews 2019
-
-// For use with Arduino Leonardo, Touch Board etc. using our sensor shield
+// For use with ATmega32u4-based boards such as the Arduino Leonardo
 #include <Adafruit_NeoPixel.h>
 #include <MIDIUSB.h>
 
-// Constants for the neopixels
+// Constants for the NeoPixels
 #define NUMPIXELS 6
 #define PIN 12
 
 // Sensor pins configuration
 #define NUMSENSORS 6
-int sensors[] = {A0, A1, A2, A3, A4, A5};
+const int sensors[NUMSENSORS] = {A0, A1, A2, A3, A4, A5};
 
 // Array to store the last sensor values to avoid duplicates
-int lastValues[] = {-1, -1, -1, -1, -1, -1};
+int lastValues[NUMSENSORS] = {-1, -1, -1, -1, -1, -1};
 
-Adafruit_NeoPixel pixels = Adafruit_NeoPixel(NUMPIXELS, PIN, NEO_GRB + NEO_KHZ800);
-MIDIEvent e;
+// Initialize NeoPixels
+Adafruit_NeoPixel pixels(NUMPIXELS, PIN, NEO_GRB + NEO_KHZ800);
+
+// Optional: Debounce variables to prevent rapid MIDI messages
+const unsigned long debounceDelay = 10; // milliseconds
+unsigned long lastDebounceTime[NUMSENSORS] = {0};
+
+// Helper function to send Control Change MIDI messages
+void sendControlChange(uint8_t channel, uint8_t control, uint8_t value) {
+  midiEventPacket_t controlChange = {0x0B, 0xB0 | (channel - 1), control, value};
+  MidiUSB.sendMIDI(controlChange);
+  MidiUSB.flush(); // Ensure the MIDI message is sent immediately
+}
 
 void setup() {
   pixels.begin();
@@ -29,31 +38,37 @@ void setup() {
 }
 
 void loop() {
-  int values[8];
+  int values[NUMSENSORS];
   bool changeFlag = false;
  
   for (int i = 0; i < NUMSENSORS; i++) {
     // Read the sensor value, map it to a range of 0-127, and invert it
     values[i] = constrain((127 - (analogRead(sensors[i]) / 8) - 50), 0, 127); 
-    //my current im boards only send a limited range, so boost this back up to 0-127
+    // Current IM boards only send a limited range, so boost this back up to 0-127
     values[i] = constrain(map(values[i], 0, 76, 0, 127), 0, 127);
     
+    Serial.print("Sensor ");
+    Serial.print(i);
+    Serial.print(": ");
     Serial.print(values[i]);
-    Serial.print(" ");
+    Serial.print(" | ");
 
-    // Send MIDI message if sensor value has changed
-    if (values[i] != lastValues[i]) {
-      e.m1 = 176; // Control Change message on channel 1
-      e.m2 = i;   // CC number based on sensor index
-      e.m3 = values[i]; // CC value from the sensor
-      e.type = 11; // Correct type for Control Change (CC)
-                      
-      MIDIUSB.write(e);
-    
+    // Debounce check: Only send MIDI if enough time has passed since the last change
+    if (values[i] != lastValues[i] && (millis() - lastDebounceTime[i] > debounceDelay)) {
+      sendControlChange(1, i, values[i]); // Control Change on channel 1
+
       lastValues[i] = values[i];
+      lastDebounceTime[i] = millis();
       
-      // Update neopixel colors based on sensor values
-      pixels.setPixelColor(i, pixels.Color(values[i] / 2, constrain(values[i] / 3 - 50, 0, 127), constrain(values[i] / 3 - 50, 0, 127)));
+      // Update the NeoPixel colors based on sensor values (red only)
+      pixels.setPixelColor(
+        i, 
+        pixels.Color(
+          values[i] / 2, 
+          constrain(values[i] / 3 - 50, 0, 127), 
+          constrain(values[i] / 3 - 50, 0, 127)
+        )
+      );
       changeFlag = true;
     }
   }


### PR DESCRIPTION
Since our custom code does not integrate any of the additional features of the Bare Conductive Touch Board at this time (such as general MIDI output), and there has been some confusion regarding what we are offering when we present our boards as an extension of the Touch Board, I am removing the dependency on the Touch Board core for now. In the past we have recommended using this so that the boards are interchangeable with Leonardo, etc.

Furthermore, availability for the Touch Board has been limited in recent years, so we will have to find our own path for the foreseeable future.  

In concrete terms, this has meant reworking the code to fit with more common use of MIDIUSB.h (I can't claim to fully understand the Bare Conductive implementation), so this should make it a bit more flexible moving forward.  I'll continue working with the Touch Board code in another repo.

Much love and respect to the Bare Conductive team who inspired this project and often gave us a signal boost on related work!  